### PR TITLE
Update settings_general.gd

### DIFF
--- a/addons/dialogic/Editor/Settings/settings_general.gd
+++ b/addons/dialogic/Editor/Settings/settings_general.gd
@@ -213,7 +213,7 @@ func build_event_editor() -> void:
 func clear_game_state(clear_flag:=Dialogic.ClearFlags.FULL_CLEAR):
 	pass
 
-func load_game_state():
+func load_game_state(load_flag:=LoadFlags.FULL_LOAD) -> void:
 	pass
 
 


### PR DESCRIPTION
Place the proper signature for load_game_state

addressing
  res://addons/dialogic_additions/Hokuspokus/subsystem_hokuspokus.gd:13 - Parse Error: The function signature doesn't match the parent. Parent signature is "load_game_state(DialogicSubsystem.LoadFlags = <default>) -> void".
when creating a fresh subsystem from settings.